### PR TITLE
Shift Hosting Links to .env file

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_HOST="https://link-my-links.vercel.app"

--- a/client/src/components/AddLink/AddLink.js
+++ b/client/src/components/AddLink/AddLink.js
@@ -7,7 +7,7 @@ import "./AddLink.css";
 import "./Modal.css";
 
 const AddLink = () => {
-  // const host = "http://192.168.29.73:9000";
+   // const host = process.env.REACT_APP_HOST;
 
   const openModal = useRef(null);
   const closeModal = useRef(null);

--- a/client/src/context/links/LinkState.js
+++ b/client/src/context/links/LinkState.js
@@ -3,7 +3,7 @@ import AlertContext from "../alerts/alertContext";
 import LinkContext from "./linkContext";
 
 const LinkState = (props) => {
-  const host = "https://link-my-links.vercel.app";
+  const host = process.env.REACT_APP_HOST;
 
   const [links, setLinks] = useState([]);
 

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -6,8 +6,6 @@ import {useNavigate} from 'react-router-dom';
 import AlertContext from '../../context/alerts/alertContext'
 
 const Login = () => {
-  const host = "https://link-my-links.vercel.app";
-
   const navigate = useNavigate();
 
   // Importing alert context
@@ -21,7 +19,7 @@ const Login = () => {
 
   const handleClick = async () => {
     // Doing a API CALL
-    const response = await fetch(`${host}/api/auth/login`, {
+    const response = await fetch(`${process.env.REACT_APP_HOST}/api/auth/login`, {
       method: 'POST', 
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/pages/Signup/Signup.js
+++ b/client/src/pages/Signup/Signup.js
@@ -6,8 +6,6 @@ import {useNavigate} from 'react-router-dom';
 import AlertContext from '../../context/alerts/alertContext'
 
 const Signup = () => {
-  const host = "https://link-my-links.vercel.app";
-
   const navigate = useNavigate();
 
   // Importing alert context
@@ -22,7 +20,7 @@ const Signup = () => {
 
   const handleClick = async () => {
     // Doing a API CALL
-    const response = await fetch(`${host}/api/auth/createuser`, {
+    const response = await fetch(`${process.env.REACT_APP_HOST}/api/auth/createuser`, {
       method: 'POST', 
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
#7 
@whysosaket 
I added .env file (as .env.example so it can be pushed to "github") and put the host link there.
I access the link from wherever it require in frontend app with: process.env.REACT_APP_HOST.
If it used in component only once I put it right at the use place, if it used in few location I assign it to variable host and use the host wherever required. 
In order do deploy this changes - New key value pair should be added to "Netlify" Environment Variables:
Key - REACT_APP_HOST
Value - https://link-my-links.vercel.app